### PR TITLE
Add `user-info` & `server-info` commands and create embeds folder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-bot-template",
-  "version": "2.0.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-bot-template",
-      "version": "2.0.0",
+      "version": "2.5.0",
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot-template",
-  "version": "2.0.0",
+  "version": "2.5.0",
   "description": "Discord bot template",
   "main": "src/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "scripts": {
     "dev": "nodemon --experimental-specifier-resolution=node src/index.js",
     "start": "node --experimental-specifier-resolution=node src/index.js",
-    "commands:deploy": "node --experimental-specifier-resolution=node src/deploy.js",
     "lint": "eslint src",
     "lint:fix": "eslint src --fix",
     "prepare": "husky install"

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -1,10 +1,12 @@
 import { SlashCommandBuilder } from 'discord.js';
+import { pingEmbed } from '../utils/embeds/ping/index.js';
 
 export default {
   data: new SlashCommandBuilder()
     .setName('ping')
     .setDescription('Replies with Pong!'),
   async execute(interaction) {
-    await interaction.reply('Pong!');
+    const client = interaction.client;
+    await interaction.reply({ embeds: [pingEmbed(client, interaction)] });
   }
 };

--- a/src/commands/serverinfo.js
+++ b/src/commands/serverinfo.js
@@ -1,0 +1,22 @@
+import { SlashCommandBuilder } from 'discord.js';
+import { serverInfoEmbed, guildError } from '../utils/embeds/server/index.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('server-info')
+    .setDescription('Displays information about the server'),
+  async execute(interaction) {
+    const { guild } = interaction;
+
+    if (!guild) {
+      return interaction.reply({
+        embeds: [guildError()],
+        ephemeral: true
+      });
+    }
+
+    const owner = await guild.fetchOwner();
+
+    await interaction.reply({ embeds: [serverInfoEmbed(guild, owner, interaction)] });
+  }
+};

--- a/src/commands/userinfo.js
+++ b/src/commands/userinfo.js
@@ -1,0 +1,19 @@
+import { SlashCommandBuilder } from 'discord.js';
+import { userInfoEmbed } from '../utils/embeds/user/index.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('user-info')
+    .setDescription('Displays information about you or another user')
+    .addUserOption(option =>
+      option.setName('target')
+        .setDescription('The user to get information about')
+        .setRequired(false)
+    ),
+  async execute(interaction) {
+    const targetUser = interaction.options.getUser('target') || interaction.user;
+    const member = interaction.guild?.members.cache.get(targetUser.id);
+
+    await interaction.reply({ embeds: [userInfoEmbed(targetUser, member, interaction)] });
+  }
+};

--- a/src/utils/embedEvents.js
+++ b/src/utils/embedEvents.js
@@ -1,0 +1,1 @@
+export const PinkColor = '#F9A8D4';

--- a/src/utils/embeds/ping/index.js
+++ b/src/utils/embeds/ping/index.js
@@ -1,0 +1,3 @@
+import pingEmbed from './pingEmbed.js';
+
+export { pingEmbed };

--- a/src/utils/embeds/ping/pingEmbed.js
+++ b/src/utils/embeds/ping/pingEmbed.js
@@ -1,0 +1,11 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function pingEmbed(client, interaction) {
+  return new EmbedBuilder()
+    .setAuthor({ name: interaction.user.displayName, iconURL: interaction.user.displayAvatarURL() ?? '' })
+    .setDescription('Pong !')
+    .setColor(PinkColor)
+    .setFooter({ text: client.user?.displayName, iconURL: client.user?.displayAvatarURL() ?? '' })
+    .setTimestamp();
+}

--- a/src/utils/embeds/server/guildError.js
+++ b/src/utils/embeds/server/guildError.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function guildError() {
+  return new EmbedBuilder()
+    .setDescription('This command can only be used in a server!')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/server/index.js
+++ b/src/utils/embeds/server/index.js
@@ -1,0 +1,4 @@
+import serverInfoEmbed from './serverEmbed.js';
+import guildError from './guildError.js';
+
+export { serverInfoEmbed, guildError };

--- a/src/utils/embeds/server/serverEmbed.js
+++ b/src/utils/embeds/server/serverEmbed.js
@@ -1,0 +1,22 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function serverInfoEmbed(guild, owner, interaction) {
+  return new EmbedBuilder()
+    .setTitle(`📜 Server Info: ${guild.name}`)
+    .setThumbnail(guild.iconURL({ dynamic: true }) || '')
+    .setColor(PinkColor)
+    .addFields(
+      { name: '👑 Owner', value: `${owner.user.tag}`, inline: true },
+      { name: '🆔 Server ID', value: `${guild.id}`, inline: true },
+      { name: '👥 Members', value: `${guild.memberCount}`, inline: true },
+      { name: '📅 Created On', value: `${guild.createdAt.toDateString()}`, inline: true },
+      { name: '🌍 Region', value: `${guild.preferredLocale}`, inline: true },
+      { name: '💬 Channels', value: `${guild.channels.cache.size}`, inline: true }
+    )
+    .setFooter({
+      text: `Requested by ${interaction.user.tag}`,
+      iconURL: interaction.user.displayAvatarURL({ dynamic: true })
+    })
+    .setTimestamp();
+}

--- a/src/utils/embeds/user/index.js
+++ b/src/utils/embeds/user/index.js
@@ -1,0 +1,3 @@
+import userInfoEmbed from './userEmbed.js';
+
+export { userInfoEmbed };

--- a/src/utils/embeds/user/userEmbed.js
+++ b/src/utils/embeds/user/userEmbed.js
@@ -1,0 +1,21 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function userInfoEmbed(targetUser, member, interaction) {
+  return new EmbedBuilder()
+    .setTitle(`User Info: ${targetUser.tag}`)
+    .setThumbnail(targetUser.displayAvatarURL({ dynamic: true }))
+    .setColor(PinkColor)
+    .addFields(
+      { name: '🆔 User ID', value: targetUser.id, inline: true },
+      { name: '🔰 Nickname', value: member?.nickname || 'None', inline: true },
+      { name: '📅 Account Created', value: `<t:${Math.floor(targetUser.createdTimestamp / 1000)}:F>`, inline: false },
+      { name: '📥 Joined Server', value: member ? `<t:${Math.floor(member.joinedTimestamp / 1000)}:F>` : 'N/A', inline: false },
+      { name: '🎨 Roles', value: member?.roles.cache.map(role => role.toString()).join(', ') || 'None', inline: false }
+    )
+    .setFooter({
+      text: `Requested by ${interaction.user.tag}`,
+      iconURL: interaction.user.displayAvatarURL({ dynamic: true })
+    })
+    .setTimestamp();
+}


### PR DESCRIPTION
## Added 2 new commands
- [x] **`user-info`**: This command displays information about a user such as user ID, username, join date, and their roles in the server.
- [x] **`server-info`**: This command displays information about the server such as server name, member count, creation date, and other relevant data.

## Added an **embeds** folder for easier management
- [x] **`guildError` and `serverEmbed`**: Code used to display server information and show error messages when data is invalid.
- [x] **`pingEmbed`**: Code used to display the result of the ping command.
- [x] **`userEmbed`**: Code used to display user information.

### Benefits
- Separating code into the **embeds** folder makes it easier to manage and maintain.
- Increases flexibility for new commands and displaying results in **Embed** format.
