### PR TITLE
Add `ban` & `kick` commands and create embeds/kick & ban folders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-bot-template",
-  "version": "2.5.3",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-bot-template",
-      "version": "2.5.3",
+      "version": "2.7.0",
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot-template",
-  "version": "2.5.3",
+  "version": "2.7.0",
   "description": "Discord bot template",
   "main": "src/index.js",
   "type": "module",

--- a/src/commands/manager/ban.js
+++ b/src/commands/manager/ban.js
@@ -1,0 +1,56 @@
+import { SlashCommandBuilder, PermissionFlagsBits } from 'discord.js';
+import { memberPermissions, banError, UserNotFound, FailedBan, banEmbed } from '../../utils/embeds/ban/index.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('ban')
+    .setDescription('Ban a user from the server.')
+    .addUserOption(option =>
+      option.setName('target')
+        .setDescription('The user to ban')
+        .setRequired(true))
+    .addStringOption(option =>
+      option.setName('reason')
+        .setDescription('The reason for the ban')
+        .setRequired(false)),
+  async execute(interaction) {
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.BanMembers)) {
+      return interaction.reply({
+        embeds: [memberPermissions()],
+        ephemeral: true
+      });
+    }
+
+    const targetUser = interaction.options.getUser('target');
+    if (!targetUser) {
+      return interaction.reply({
+        embeds: [banError()],
+        ephemeral: true
+      });
+    }
+
+    const reason = interaction.options.getString('reason') || 'No reason provided';
+    const member = await interaction.guild?.members.fetch(targetUser.id);
+
+    if (!member) {
+      return interaction.reply({
+        embeds: [UserNotFound()],
+        ephemeral: true
+      });
+    }
+
+    try {
+      await member.ban({ reason });
+      return interaction.reply({
+        embeds: [banEmbed(targetUser.tag, reason, interaction)],
+        ephemeral: true
+      });
+    } catch (error) {
+      console.error(error);
+      return interaction.reply({
+        embeds: [FailedBan()],
+        ephemeral: true
+      });
+    }
+  }
+};

--- a/src/commands/manager/kick.js
+++ b/src/commands/manager/kick.js
@@ -1,0 +1,46 @@
+import { SlashCommandBuilder, PermissionFlagsBits } from 'discord.js';
+import { memberPermissions, kickError, UserNotFound, kickEmbed, FailedKick } from '../../utils/embeds/kick/index.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('kick')
+    .setDescription('Kick a user from the server.')
+    .addUserOption(option =>
+      option.setName('target')
+        .setDescription('The user to kick')
+        .setRequired(true)),
+  async execute(interaction) {
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.KickMembers)) {
+      return interaction.reply({
+        embeds: [memberPermissions()],
+        ephemeral: true
+      });
+    }
+
+    const targetUser = interaction.options.getUser('target');
+    if (!targetUser) {
+      return interaction.reply({
+        embeds: [kickError()],
+        ephemeral: true
+      });
+    }
+
+    const member = await interaction.guild?.members.fetch(targetUser.id);
+    if (!member) {
+      return interaction.reply({
+        embeds: [UserNotFound()],
+        ephemeral: true
+      });
+    }
+
+    try {
+      await member.kick();
+      return interaction.reply({ embeds: [kickEmbed(targetUser.tag, interaction)], ephemeral: true });
+    } catch (error) {
+      return interaction.reply({
+        embeds: [FailedKick()],
+        ephemeral: true
+      });
+    }
+  }
+};

--- a/src/utils/embeds/ban/banEmbed.js
+++ b/src/utils/embeds/ban/banEmbed.js
@@ -1,0 +1,13 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function banEmbed(targetUser, reason, interaction) {
+  return new EmbedBuilder()
+    .setDescription(`${targetUser} has been banned from the server. Reason: ${reason}`)
+    .setFooter({
+      text: `Requested by ${interaction.user.tag}`,
+      iconURL: interaction.user.displayAvatarURL()
+    })
+    .setColor(PinkColor)
+    .setTimestamp();
+}

--- a/src/utils/embeds/ban/banError.js
+++ b/src/utils/embeds/ban/banError.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function banError() {
+  return new EmbedBuilder()
+    .setDescription('Please provide a valid user to ban.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/ban/failedban.js
+++ b/src/utils/embeds/ban/failedban.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function FailedBan() {
+  return new EmbedBuilder()
+    .setDescription('Failed to ban the user. Please try again later.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/ban/index.js
+++ b/src/utils/embeds/ban/index.js
@@ -1,0 +1,13 @@
+import memberPermissions from './memberPermissions.js';
+import banError from './banError.js';
+import UserNotFound from './userNotFound.js';
+import FailedBan from './failedban.js';
+import banEmbed from './banEmbed.js';
+
+export {
+  memberPermissions,
+  banError,
+  UserNotFound,
+  FailedBan,
+  banEmbed
+};

--- a/src/utils/embeds/ban/memberPermissions.js
+++ b/src/utils/embeds/ban/memberPermissions.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function memberPermissions() {
+  return new EmbedBuilder()
+    .setDescription('You do not have permission to ban members.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/ban/userNotFound.js
+++ b/src/utils/embeds/ban/userNotFound.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function UserNotFound() {
+  return new EmbedBuilder()
+    .setDescription('User not found in the server.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/kick/failedKick.js
+++ b/src/utils/embeds/kick/failedKick.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function FailedKick() {
+  return new EmbedBuilder()
+    .setDescription('Failed to kick the user. Please try again later.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/kick/index.js
+++ b/src/utils/embeds/kick/index.js
@@ -1,0 +1,13 @@
+import memberPermissions from './memberPermissions.js';
+import kickError from './kickError.js';
+import UserNotFound from './userNotFound.js';
+import kickEmbed from './kickEmbed.js';
+import FailedKick from './failedKick.js';
+
+export {
+  memberPermissions,
+  kickError,
+  UserNotFound,
+  kickEmbed,
+  FailedKick
+};

--- a/src/utils/embeds/kick/kickEmbed.js
+++ b/src/utils/embeds/kick/kickEmbed.js
@@ -1,0 +1,13 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function kickEmbed(targetUser, interaction) {
+  return new EmbedBuilder()
+    .setDescription(`${targetUser} has been kicked from the server.`)
+    .setFooter({
+      text: `Requested by ${interaction.user.tag}`,
+      iconURL: interaction.user.displayAvatarURL()
+    })
+    .setColor(PinkColor)
+    .setTimestamp();
+}

--- a/src/utils/embeds/kick/kickError.js
+++ b/src/utils/embeds/kick/kickError.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function kickError() {
+  return new EmbedBuilder()
+    .setDescription('Please provide a valid user to kick.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/kick/memberPermissions.js
+++ b/src/utils/embeds/kick/memberPermissions.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function memberPermissions() {
+  return new EmbedBuilder()
+    .setDescription('You do not have permission to kick members.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/kick/userNotFound.js
+++ b/src/utils/embeds/kick/userNotFound.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function UserNotFound() {
+  return new EmbedBuilder()
+    .setDescription('User not found in the server.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/ping/pingEmbed.js
+++ b/src/utils/embeds/ping/pingEmbed.js
@@ -2,9 +2,12 @@ import { EmbedBuilder } from 'discord.js';
 import { PinkColor } from '../../embedEvents.js';
 
 export default function pingEmbed(client, interaction) {
+  const latency = client.ws.ping;
+  const apiLatency = Date.now() - interaction.createdTimestamp;
+
   return new EmbedBuilder()
     .setAuthor({ name: interaction.user.displayName, iconURL: interaction.user.displayAvatarURL() ?? '' })
-    .setDescription('Pong !')
+    .setDescription(`Pong! 🏓\n**API Latency**: ${apiLatency}ms\n**WebSocket Latency**: ${latency}ms`)
     .setColor(PinkColor)
     .setFooter({ text: client.user?.displayName, iconURL: client.user?.displayAvatarURL() ?? '' })
     .setTimestamp();


### PR DESCRIPTION
## Recent Changes and Improvements

### New Commands Added

1. [x] **`ping` Command**
   - Added a response for the `ping` command to show the latency between the bot and the Discord API along with the current time.

2. [x] **`kick` Command**
   - Added the `kick` command that allows users with the `KICK_MEMBERS` permission to kick other users from the server. The bot checks the user's permissions before performing the kick.

3. [x] **`ban` Command**
   - Added the `ban` command that allows users to ban other users from the server. It supports specifying a ban reason and checks the user's permissions before performing the ban.

### Permission Check Improvements

- [x] Fixed the permission checks for `KICK_MEMBERS` and `BAN_MEMBERS` to use the appropriate `PermissionFlagsBits` for Discord.js version 14 and above, as the older method caused the "Invalid bitfield flag or number" error.

### Output Enhancements

- [x] Improved the responses for the `kick` and `ban` commands to provide clearer messages, such as displaying the ban reason and showing aesthetically pleasing messages when successfully kicking or banning users.

---

## Development Timeline

### 🗓️ January 2025

**January 18, 2025**  
- Improved the response for the `ping` command to show the actual latency.
- Added the feature to specify a reason when banning a user (`ban`) and provided clear messages when banning users.
- Fixed the permission check issue for the `kick` and `ban` commands to be compatible with Discord.js version 14 and above.