### PR TITLE
Add a `mute` command and create a folder embeds/mute.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-bot-template",
-  "version": "2.7.0",
+  "version": "2.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-bot-template",
-      "version": "2.7.0",
+      "version": "2.7.5",
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "discord-bot-template",
-  "version": "2.7.5",
+  "version": "2.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "discord-bot-template",
-      "version": "2.7.5",
+      "version": "2.7.1",
       "license": "MIT",
       "dependencies": {
         "@discordjs/builders": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot-template",
-  "version": "2.7.0",
+  "version": "2.7.5",
   "description": "Discord bot template",
   "main": "src/index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discord-bot-template",
-  "version": "2.7.5",
+  "version": "2.7.1",
   "description": "Discord bot template",
   "main": "src/index.js",
   "type": "module",

--- a/src/commands/manager/ban.js
+++ b/src/commands/manager/ban.js
@@ -12,7 +12,8 @@ export default {
     .addStringOption(option =>
       option.setName('reason')
         .setDescription('The reason for the ban')
-        .setRequired(false)),
+        .setRequired(false))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
   async execute(interaction) {
     if (!interaction.memberPermissions?.has(PermissionFlagsBits.BanMembers)) {
       return interaction.reply({

--- a/src/commands/manager/kick.js
+++ b/src/commands/manager/kick.js
@@ -8,7 +8,8 @@ export default {
     .addUserOption(option =>
       option.setName('target')
         .setDescription('The user to kick')
-        .setRequired(true)),
+        .setRequired(true))
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
   async execute(interaction) {
     if (!interaction.memberPermissions?.has(PermissionFlagsBits.KickMembers)) {
       return interaction.reply({

--- a/src/commands/manager/mute.js
+++ b/src/commands/manager/mute.js
@@ -1,0 +1,63 @@
+import { PermissionFlagsBits, SlashCommandBuilder } from 'discord.js';
+import { memberError, moderatableError, muteEmbed, FailedMute } from '../../utils/embeds/mute/index.js';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('mute')
+    .setDescription('Mute a user temporarily.')
+    .addUserOption(option =>
+      option
+        .setName('target')
+        .setDescription('The user to mute')
+        .setRequired(true)
+    )
+    .addIntegerOption(option =>
+      option
+        .setName('duration')
+        .setDescription('Mute duration in minutes')
+        .setRequired(true)
+    )
+    .addStringOption(option =>
+      option
+        .setName('reason')
+        .setDescription('Reason for muting the user')
+        .setRequired(false)
+    )
+    .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+  async execute(interaction) {
+    const target = interaction.options.getUser('target');
+    const member = interaction.guild.members.cache.get(target.id);
+    const duration = interaction.options.getInteger('duration');
+    const reason = interaction.options.getString('reason') || 'No reason provided.';
+
+    if (!member) {
+      return interaction.reply({
+        embeds: [memberError()],
+        ephemeral: true
+      });
+    }
+
+    if (!member.moderatable) {
+      return interaction.reply({
+        embeds: [moderatableError()],
+        ephemeral: true
+      });
+    }
+
+    const milliseconds = duration * 60 * 1000;
+
+    try {
+      await member.timeout(milliseconds, reason);
+      return interaction.reply({
+        embeds: [muteEmbed(member.user.tag, duration, reason, interaction)],
+        ephemeral: true
+      });
+    } catch (error) {
+      console.error(error);
+      return interaction.reply({
+        embeds: [FailedMute(member.user.tag)],
+        ephemeral: true
+      });
+    }
+  }
+};

--- a/src/utils/embeds/mute/failedMute.js
+++ b/src/utils/embeds/mute/failedMute.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function FailedMute(memberTag) {
+  return new EmbedBuilder()
+    .setDescription(`Failed to mute ${memberTag}.`)
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/mute/index.js
+++ b/src/utils/embeds/mute/index.js
@@ -1,0 +1,6 @@
+import memberError from './memberError.js';
+import moderatableError from './moderatableError.js';
+import muteEmbed from './muteEmbed.js';
+import FailedMute from './failedMute.js';
+
+export { memberError, moderatableError, muteEmbed, FailedMute };

--- a/src/utils/embeds/mute/memberError.js
+++ b/src/utils/embeds/mute/memberError.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function memberError() {
+  return new EmbedBuilder()
+    .setDescription('Cannot find the user.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/mute/moderatableError.js
+++ b/src/utils/embeds/mute/moderatableError.js
@@ -1,0 +1,8 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function moderatableError() {
+  return new EmbedBuilder()
+    .setDescription('I cannot mute this user.')
+    .setColor(PinkColor);
+}

--- a/src/utils/embeds/mute/muteEmbed.js
+++ b/src/utils/embeds/mute/muteEmbed.js
@@ -1,0 +1,13 @@
+import { EmbedBuilder } from 'discord.js';
+import { PinkColor } from '../../embedEvents.js';
+
+export default function muteEmbed(memberTag, duration, reason, interaction) {
+  return new EmbedBuilder()
+    .setDescription(`Successfully muted ${memberTag} for ${duration} minute(s). Reason: ${reason}`)
+    .setColor(PinkColor)
+    .setFooter({
+      text: `Requested by ${interaction.user.tag}`,
+      iconURL: interaction.user.displayAvatarURL()
+    })
+    .setTimestamp();
+}


### PR DESCRIPTION
## Newly Added Commands

1. [x] **Command `mute`**
   - Added the `mute` command to temporarily mute members.
   - Allows specifying the duration (in minutes) and the reason for muting.
   - Utilizes Discord's timeout feature and verifies the user's `MODERATE_MEMBERS` permission before executing.

## Folder Structure Update

- Added a new folder `embeds/mute` to manage embed events for the `mute` command.